### PR TITLE
Fix linearsmooth not set to bg-image in systemview but set in gamelistview

### DIFF
--- a/_art/systemView/setArtGallery.xml
+++ b/_art/systemView/setArtGallery.xml
@@ -14,6 +14,7 @@
 			<path>./background-default.jpg</path>
 			<path>./../../${system.theme}/background.jpg</path>
 			<color>ffffffff</color>
+			<linearSmooth>true</linearSmooth>
 			<tile>false</tile> <!-- Repeat / Streach image -->
 			<zIndex>10</zIndex> <!-- Default 10 for extra -->
 		</image>

--- a/_art/systemView/setLibrary.xml
+++ b/_art/systemView/setLibrary.xml
@@ -14,6 +14,7 @@
 			<path>./background-default.jpg</path>
 			<path>./../../${system.theme}/background.jpg</path>
 			<color>ffffffff</color>
+			<linearSmooth>true</linearSmooth>
 			<tile>false</tile> <!-- Repeat / Streach image -->
 			<zIndex>10</zIndex> <!-- Default 10 for extra -->
 		</image>


### PR DESCRIPTION
-> resource is not reused, but loaded 2 times. Very visible on slow systems ( like rpi )